### PR TITLE
[Comma Dangle] rule disabled due to trailing-comma being true in Prettier v3 by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,8 @@ module.exports = {
     // turning this rule off because prettier doesn't support it
     // and it's not really that important
     'space-before-function-paren': 'off',
+    // disabling because in Prettier v3 trailing-commas are now the default
+    "comma-dangle": "off",
   },
   env: {
     'jest/globals': true,


### PR DESCRIPTION
## Summary
Deciding to rule with Prettier v3 trailing comma default setting of true so the the `comma-dangle` rule is in direct conflict with it.
